### PR TITLE
add level 1

### DIFF
--- a/container/agents/buddha_agent.py
+++ b/container/agents/buddha_agent.py
@@ -136,6 +136,7 @@ def get_default_buddha_agent(language: Language = Language.VI) -> Agent:
         language=language,
         model="gpt-4o",
         temperature=0,
+        level=1,
         uuid="buddha_agent",
         agent_type="buddha_agent",
         system_prompt=SYSTEM_PROMPT_VI if language == Language.VI else SYSTEM_PROMPT_EN

--- a/container/services/handle_ask.py
+++ b/container/services/handle_ask.py
@@ -50,6 +50,7 @@ def get_agent(agent_id: str, language: Language) -> Agent:
         system_prompt=agent["system_prompt"],
         tools=agent["tools"],
         model=agent["model"],
+        level=1,
         temperature=agent["temperature"],
         language=agent["language"],
         created_at=agent["created_at"],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Introduced an Agent “level” attribute available across the app.
  - Default level is set to 1 for newly created and loaded agents, including the Buddha agent.
  - Enables displaying and organizing agents by level and prepares for level-aware behaviors.
  - Backward compatible: existing agents will use the default level with no action required from users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->